### PR TITLE
Add Logger interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ func main() {
 			Checkpoint:  &c,
 			Emitter:     &e,
 			Filter:      &f,
+			Logger:      log.New(os.Stdout, "KINESIS: ", log.Ldate|log.Ltime|log.Lshortfile),
 			StreamName:  cfg.Kinesis.InputStream,
 			Transformer: &t,
 		}
@@ -144,6 +145,7 @@ func main() {
 			Checkpoint:  &c,
 			Emitter:     &e,
 			Filter:      &f,
+			Logger:      log.New(os.Stdout, "KINESIS: ", log.Ldate|log.Ltime|log.Lshortfile),
 			StreamName:  cfg.Kinesis.OutputStream,
 			Transformer: &t,
 		}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,8 @@
+package connector
+
+// Logger sends pipeline info and errors to logging endpoint. The logger could be
+// used to send to STDOUT, Syslog, or any number of distributed log collecting platforms.
+type Logger interface {
+	Fatalf(format string, v ...interface{})
+	Printf(format string, v ...interface{})
+}

--- a/redshift_basic_emitter_test.go
+++ b/redshift_basic_emitter_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestCopyStatement(t *testing.T) {
-	e := RedshiftBasicEmtitter{
+	e := RedshiftBasicEmitter{
 		Delimiter: ",",
 		S3Bucket:  "test_bucket",
 		TableName: "test_table",

--- a/redshift_manifest_emitter.go
+++ b/redshift_manifest_emitter.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -25,6 +24,7 @@ type RedshiftManifestEmitter struct {
 	FileTable     string
 	Format        string
 	Jsonpaths     string
+	Logger        Logger
 	S3Bucket      string
 	SecretKey     string
 }
@@ -35,7 +35,7 @@ func (e RedshiftManifestEmitter) Emit(b Buffer, t Transformer) {
 	db, err := sql.Open("postgres", os.Getenv("REDSHIFT_URL"))
 
 	if err != nil {
-		log.Fatal(err)
+		e.Logger.Fatalf("sql.Open ERROR: %v\n", err)
 	}
 
 	// Aggregate file paths as strings
@@ -55,7 +55,7 @@ func (e RedshiftManifestEmitter) Emit(b Buffer, t Transformer) {
 	_, err = db.Exec(c)
 
 	if err != nil {
-		log.Fatal(err)
+		e.Logger.Fatalf("db.Exec ERROR: %v\n", err)
 	}
 
 	// Insert file paths into File Names table
@@ -63,10 +63,10 @@ func (e RedshiftManifestEmitter) Emit(b Buffer, t Transformer) {
 	_, err = db.Exec(i)
 
 	if err != nil {
-		log.Fatal(err)
+		e.Logger.Fatalf("db.Exec ERROR: %v\n", err)
 	}
 
-	log.Printf("[%v] copied to Redshift", manifestFileName)
+	e.Logger.Printf("[%v] copied to Redshift", manifestFileName)
 	db.Close()
 }
 

--- a/s3_emitter.go
+++ b/s3_emitter.go
@@ -3,7 +3,6 @@ package connector
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/crowdmob/goamz/aws"
@@ -17,6 +16,7 @@ import (
 // from the first and last sequence numbers of the records contained in that file separated by a
 // dash. This struct requires the configuration of an S3 bucket and endpoint.
 type S3Emitter struct {
+	Logger   Logger
 	S3Bucket string
 }
 
@@ -44,8 +44,8 @@ func (e S3Emitter) Emit(b Buffer, t Transformer) {
 	err := bucket.Put(s3File, buffer.Bytes(), "text/plain", s3.Private, s3.Options{})
 
 	if err != nil {
-		log.Printf("S3Put ERROR: %v\n", err)
+		e.Logger.Fatalf("S3Put ERROR: %v\n", err.Error())
 	} else {
-		log.Printf("[%v] records emitted to [%s]\n", b.NumRecordsInBuffer(), e.S3Bucket)
+		e.Logger.Printf("[%v] records emitted to [%s]\n", b.NumRecordsInBuffer(), e.S3Bucket)
 	}
 }

--- a/s3_manifest_emitter.go
+++ b/s3_manifest_emitter.go
@@ -1,8 +1,6 @@
 package connector
 
 import (
-	"log"
-
 	"github.com/sendgridlabs/go-kinesis"
 )
 
@@ -12,6 +10,7 @@ type S3ManifestEmitter struct {
 	OutputStream string
 	S3Bucket     string
 	Ksis         *kinesis.Kinesis
+	Logger       Logger
 }
 
 func (e S3ManifestEmitter) Emit(b Buffer, t Transformer) {
@@ -30,8 +29,8 @@ func (e S3ManifestEmitter) Emit(b Buffer, t Transformer) {
 	_, err := e.Ksis.PutRecord(args)
 
 	if err != nil {
-		log.Printf("PutRecord ERROR: %v", err)
+		e.Logger.Printf("PutRecord ERROR: %v", err)
 	} else {
-		log.Printf("[%s] emitted to [%s]", b.FirstSequenceNumber(), e.OutputStream)
+		e.Logger.Printf("[%s] emitted to [%s]", b.FirstSequenceNumber(), e.OutputStream)
 	}
 }


### PR DESCRIPTION
@superbaddude will this suffice for passing in your `log4go` library? It seemed like the path of least resistance to keep a similar interface to `log` package, but I could be persuaded otherwise if there is a good argument for changing the function names.

To allow for different logging endpoints we'll introduce a Logger
interface that will be passed into the pipeline during initialization.

* Add Logger interface
* Update pipeline to use Logger instead of log